### PR TITLE
Add property to enable dropping sei nal units from H.264 stream

### DIFF
--- a/gst/rtp/gstrtph264depay.c
+++ b/gst/rtp/gstrtph264depay.c
@@ -83,7 +83,7 @@ G_DEFINE_TYPE (GstRtpH264Depay, gst_rtp_h264_depay,
     GST_TYPE_RTP_BASE_DEPAYLOAD);
 
 
-#define DEFAULT_DROP_SEI_NAL    FALSE
+#define DEFAULT_DROP_SEI_NAL    TRUE
 
 enum
 {
@@ -125,7 +125,7 @@ gst_rtp_h264_depay_class_init (GstRtpH264DepayClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_DROP_SEI_NAL,
       g_param_spec_boolean ("drop-sei-nal", "Drop SEI nal units",
-          "Drop SEI nal units when detected in H.264 stream. Default is false (disabled).",
+          "Drop SEI nal units when detected in H.264 stream. Default is true (enabled).",
           DEFAULT_DROP_SEI_NAL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_static_pad_template (gstelement_class,

--- a/gst/rtp/gstrtph264depay.h
+++ b/gst/rtp/gstrtph264depay.h
@@ -66,6 +66,7 @@ struct _GstRtpH264Depay
   GPtrArray *sps;
   GPtrArray *pps;
   gboolean new_codec_data;
+  gboolean drop_sei_nal;
 };
 
 struct _GstRtpH264DepayClass


### PR DESCRIPTION
The following changes add a new property in the rtph264depay plugin which allows to enable dropping SEI frames in the H.264 stream. This is a possible fix for the memory leaks observed when using the Herospeed camera.